### PR TITLE
No Exceptions when no audited changes. Only record changed audited fields.

### DIFF
--- a/lib/simple_audit_trail.rb
+++ b/lib/simple_audit_trail.rb
@@ -22,19 +22,22 @@ module SimpleAuditTrail
 
         before_update :save_audits
         define_method :save_audits do
-          if self.audited_user_id.nil? && self.audit_options[:require_audited_user_id]
-            raise "audited setter method called without setting audited_user_id"
+          changed_audited_fields = audited_fields.select do |f|
+            send "#{f}_changed?"
           end
-          if (self.changed & self.audited_fields).any?
-            to = Hash[self.audited_fields.map{|k| [k,self[k]]}]
-            from = to.clone.merge! Hash[
-              self.changes.slice(*self.audited_fields).map{|k,v| [k,v[0]]}
-            ]
 
-            self.simple_audits.create(
+          if changed_audited_fields.present?
+            if audited_user_id.nil? && audit_options[:require_audited_user_id]
+              raise "audited setter method called without setting audited_user_id"
+            end
+
+            to = Hash[changed_audited_fields.map { |f| [f, send(f)] }]
+            from = Hash[changed_audited_fields.map { |f| [f, send("#{f}_was")] }]
+
+            simple_audits.create(
               :from => from.to_json,
               :to => to.to_json,
-              :who_id => self.audited_user_id)
+              :who_id => audited_user_id)
           end
         end
       end

--- a/lib/simple_audit_trail/version.rb
+++ b/lib/simple_audit_trail/version.rb
@@ -1,3 +1,3 @@
 module SimpleAuditTrail
-  VERSION = "0.0.1"
+  VERSION = "0.0.2"
 end


### PR DESCRIPTION
A boatload of my rspecs were failing when I added this.  I found that I was getting the "No Auditor Exception" even when I was leaving all my audited fields `nil` and unchanged.  I modified this to not raise the exception unless something audited has changed.

In my refactoring I found that all audited fields are recorded regardless if they have changed or not.  This will make it so only the audited fields that actually changed are recorded.