### PR TITLE
Unchanged audited values are recorded in `unchanged` column, not with `to` and `from`.

### DIFF
--- a/app/models/simple_audit_trail/audit.rb
+++ b/app/models/simple_audit_trail/audit.rb
@@ -1,6 +1,6 @@
 module SimpleAuditTrail
   class Audit < ActiveRecord::Base
-    attr_accessible :from, :to, :who_id
+    attr_accessible :from, :to, :who_id, :unchanged
     belongs_to :simple_audit_trailable, :polymorphic => true
     def self.table_name
       "simple_audit_trail_audits"

--- a/lib/simple_audit_trail.rb
+++ b/lib/simple_audit_trail.rb
@@ -31,13 +31,20 @@ module SimpleAuditTrail
               raise "audited setter method called without setting audited_user_id"
             end
 
-            to = Hash[audited_fields.map { |f| [f, send(f)] }]
-            from = Hash[audited_fields.map { |f| [f, send("#{f}_was")] }]
+            to = Hash[changed_audited_fields.map { |f| [f, send(f)] }]
+            from = Hash[changed_audited_fields.map { |f| [f, send("#{f}_was")] }]
+            unchanged = Hash[
+              (audited_fields - changed_audited_fields).map do |f|
+                [f, send(f)]
+              end
+            ]
 
             simple_audits.create(
               :from => from.to_json,
               :to => to.to_json,
-              :who_id => audited_user_id)
+              :unchanged => unchanged.to_json,
+              :who_id => audited_user_id
+            )
           end
         end
       end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150513221356) do
+ActiveRecord::Schema.define(:version => 20150701174723) do
 
   create_table "mr_torques", :force => true do |t|
     t.string   "todays_quote"
@@ -27,6 +27,7 @@ ActiveRecord::Schema.define(:version => 20150513221356) do
     t.text     "to"
     t.datetime "created_at",                  :null => false
     t.datetime "updated_at",                  :null => false
+    t.text     "unchanged"
   end
 
   create_table "tinas", :force => true do |t|

--- a/spec/lib/simple_audit_trail_auditor_spec.rb
+++ b/spec/lib/simple_audit_trail_auditor_spec.rb
@@ -65,6 +65,10 @@ describe SimpleAuditTrail::Auditor do
             it "has a who_id for the user who made the change" do
               expect(@tina.simple_audits.last.who_id).to eq 123
             end
+
+            it "has an empty unchanged value" do
+              expect(JSON.parse(@tina.simple_audits.last.unchanged)).to be_empty
+            end
           end
         end
 
@@ -77,14 +81,19 @@ describe SimpleAuditTrail::Auditor do
             @tina.save
           end
 
-          it "has a json hash for what all the audited values were" do
+          it "has a json hash in `from` for what the changed audited values were" do
             expect(JSON.parse(@tina.simple_audits.last.from)).
-              to eq JSON.parse("{\"ladies\":0,\"badonkadonks\":0}")
+              to eq JSON.parse("{\"badonkadonks\":0}")
           end
 
-          it "has a json hash for what all the audited values are" do
+          it "has a json hash in `to` for what the changed audited values are" do
             expect(JSON.parse(@tina.simple_audits.last.to)).
-              to eq JSON.parse("{\"ladies\":0,\"badonkadonks\":1}")
+              to eq JSON.parse("{\"badonkadonks\":1}")
+          end
+
+          it "has a json hash in `unchanged` for what the unmodified audited values are" do
+            expect(JSON.parse(@tina.simple_audits.last.unchanged)).
+              to eq JSON.parse("{\"ladies\":0}")
           end
         end
 


### PR DESCRIPTION
It feels like clutter to store unchanged values with the changed values.  Create a new column to store the values that are unchanged so we know they were monitored but not altered.